### PR TITLE
Update to 4.3.0

### DIFF
--- a/DSharpPlusDocs.csproj
+++ b/DSharpPlusDocs.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <DebugType>portable</DebugType>
-        <AssemblyName>DSharpPlusDocs</AssemblyName>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="DSharpPlus" Version="4.3.0-nightly-01134" />
-        <PackageReference Include="DSharpPlus.CommandsNext" Version="4.3.0-nightly-01134" />
-        <PackageReference Include="DSharpPlus.Interactivity" Version="4.3.0-nightly-01134" />
-        <PackageReference Include="DSharpPlus.Rest" Version="4.3.0-nightly-01134" />
-        <PackageReference Include="DSharpPlus.VoiceNext" Version="4.3.0-nightly-01134" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <DebugType>portable</DebugType>
+    <AssemblyName>DSharpPlusDocs</AssemblyName>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DSharpPlus" Version="4.3.0" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.3.0" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.3.0" />
+    <PackageReference Include="DSharpPlus.Rest" Version="4.3.0" />
+    <PackageReference Include="DSharpPlus.VoiceNext" Version="4.3.0" />
+    <PackageReference Include="DSharpPlus.SlashCommands" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+  </ItemGroup>
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
 WORKDIR /src
 
 COPY ./ /src
@@ -7,7 +7,7 @@ RUN dotnet restore -r linux-musl-x64 && dotnet publish -c Release -r linux-musl-
 FROM alpine:latest
 WORKDIR /src
 
-COPY --from=build /src/bin/Release/net6.0/linux-musl-x64/publish /src
+COPY --from=build /src/bin/Release/net7.0/linux-musl-x64/publish /src
 RUN apk upgrade --update-cache --available && apk add openssl libstdc++ icu-libs && rm -rf /var/cache/apk/*
 
 ENTRYPOINT /src/DSharpPlusDocs


### PR DESCRIPTION
# Summary
This updates DocBot to use .NET 7, include the SlashCommands package upon searching and bumps the DSharpPlus deps to 4.3.0

# Notes
All completely untested.