### PR TITLE
Change base url to the new updated one

### DIFF
--- a/Handlers/QueryHandler.cs
+++ b/Handlers/QueryHandler.cs
@@ -30,7 +30,7 @@ namespace DSharpPlusDocs.Handlers
     public class QueryHandler
     {
         public Cache Cache { get; private set; }
-        public static string DocsBaseUrl { get; set; } = "https://dsharpplus.github.io/";
+        public static string DocsBaseUrl { get; set; } = "https://dsharpplus.github.io/DSharpPlus";
 
         public QueryHandler() => Cache = new Cache();
 


### PR DESCRIPTION
Now we have the fun little `/DSharpPlus` added onto the base url. Completely untested.